### PR TITLE
[NWS-1409][NWS-1468] Disabled expenses report button when contract has no expenses

### DIFF
--- a/src/app/pages/contracts/contract-dialog/contract-dialog.component.html
+++ b/src/app/pages/contracts/contract-dialog/contract-dialog.component.html
@@ -105,6 +105,7 @@
                 nbTooltipPlacement="bottom"
                 nbTooltipStatus="info"
                 style="height: 100%"
+                [disabled]="contract.expenses.length == 0"
                 (click)="downloadExpensesReport(contract)"
               >
                 <i class="icon-file-csv"></i>


### PR DESCRIPTION
Botão desabilitado num contrato sem despesas
![download_report_button_disabled](https://user-images.githubusercontent.com/26936076/169621928-f26ff732-4f90-4f7e-825d-c7dfd2593492.png)


