### PR TITLE
[NWS-1378][NWS-1597] Fix send message icon color in management tab

### DIFF
--- a/src/app/pages/contracts/contract-item/management-tab/management-tab.component.html
+++ b/src/app/pages/contracts/contract-item/management-tab/management-tab.component.html
@@ -446,7 +446,7 @@
             (click)="registerNewComment()"
             [disabled]="!commentInput.value"
           >
-            <nb-icon style="width: 20px; height: 20px" status="basic" icon="paper-plane-outline" pack="eva"></nb-icon>
+            <nb-icon style="width: 20px; height: 20px" [status]="commentInput.value ? 'control' : 'basic'" icon="paper-plane-outline" pack="eva"></nb-icon>
           </button>
         </div>
       </div>


### PR DESCRIPTION
Fiz esse PR apontando pro NWS-1596 por causa dos imports do migration.ts

Como estava antes (só era perceptível quando o botão não estava desabilitado)
Empresarial
![Screenshot from 2022-06-22 21-43-35](https://user-images.githubusercontent.com/26936076/175183725-fe0e4ad1-486c-4e66-9bfe-3f759704720b.png)
Cósmico
![Screenshot from 2022-06-22 21-44-23](https://user-images.githubusercontent.com/26936076/175183793-058713ac-ce82-4ee5-a81a-afd0778dc5b6.png)
Escuro
![Screenshot from 2022-06-22 21-43-14](https://user-images.githubusercontent.com/26936076/175183727-a3adfd1b-2c2c-4c75-8598-f29df3ffa22e.png)
Claro
![Screenshot from 2022-06-22 21-45-09](https://user-images.githubusercontent.com/26936076/175183853-891db42c-7eb4-4949-8dee-b08014d58f02.png)

Com a alteração

Empresarial
![Screenshot from 2022-06-22 21-38-42](https://user-images.githubusercontent.com/26936076/175183292-1d1a2a09-308c-46e5-a3ac-7e9a55945ed1.png)
![Screenshot from 2022-06-22 21-38-33](https://user-images.githubusercontent.com/26936076/175183297-d9a0eedf-7dd2-4127-b6d1-dd147ea414e9.png)
Cósmico
![Screenshot from 2022-06-22 21-38-08](https://user-images.githubusercontent.com/26936076/175183298-cce1c54b-af31-4d62-8088-f47c4dd02f25.png)
![Screenshot from 2022-06-22 21-38-01](https://user-images.githubusercontent.com/26936076/175183299-eb0b7008-c56d-48c5-9367-68f54b50664d.png)
Escuro
![Screenshot from 2022-06-22 21-37-42](https://user-images.githubusercontent.com/26936076/175183300-c0dad7a1-bdaf-41cb-a73f-32d6ef73159d.png)
![Screenshot from 2022-06-22 21-34-57](https://user-images.githubusercontent.com/26936076/175183301-3f026572-009d-4d0f-beee-4451037fa863.png)
Claro
![Screenshot from 2022-06-22 21-34-43](https://user-images.githubusercontent.com/26936076/175183303-98f8e360-9f7b-4dda-af0e-2ca6d284a1ab.png)
![Screenshot from 2022-06-22 21-34-34](https://user-images.githubusercontent.com/26936076/175183304-824542ff-69c5-4b2e-8c10-03259ce229d0.png)
