### PR TITLE
[NWS-1224][NWS-1580] Align text with toggles in platform configs

### DIFF
--- a/src/app/@theme/components/header/config/config.component.html
+++ b/src/app/@theme/components/header/config/config.component.html
@@ -278,7 +278,7 @@
             <table class="table-invoice">
               <tbody>
                 <tr>
-                  <td>Tipo de orçamento</td>
+                  <td class="td-left">Tipo de orçamento</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.invoiceConfig.hasType"
@@ -288,7 +288,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Cabeçalho</td>
+                  <td class="td-left">Cabeçalho</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.invoiceConfig.hasHeader"
@@ -298,7 +298,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Lista de colaboradores</td>
+                  <td class="td-left">Lista de colaboradores</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.invoiceConfig.hasTeam"
@@ -308,7 +308,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Etapa preliminar</td>
+                  <td class="td-left">Etapa preliminar</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.invoiceConfig.hasPreliminary"
@@ -318,7 +318,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Etapa executiva</td>
+                  <td class="td-left">Etapa executiva</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.invoiceConfig.hasExecutive"
@@ -328,7 +328,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Etapa complementar</td>
+                  <td class="td-left">Etapa complementar</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.invoiceConfig.hasComplementary"
@@ -338,7 +338,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Parcelamentos</td>
+                  <td class="td-left">Parcelamentos</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.invoiceConfig.hasStageName"
@@ -348,7 +348,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Importantes</td>
+                  <td class="td-left">Importantes</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.invoiceConfig.hasImportants"
@@ -358,7 +358,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Lista de materiais</td>
+                  <td class="td-left">Lista de materiais</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.invoiceConfig.hasMaterialList"
@@ -485,7 +485,7 @@
             <table class="table-profile">
               <tbody>
                 <tr>
-                  <td>Enquadramentos</td>
+                  <td class="td-left">Enquadramentos</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.profileConfig.hasLevels"
@@ -495,7 +495,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Lista de times</td>
+                  <td class="td-left">Lista de times</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.profileConfig.hasTeam"
@@ -505,7 +505,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Lista de setores</td>
+                  <td class="td-left">Lista de setores</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.profileConfig.hasSector"
@@ -515,7 +515,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Perfil de atuação</td>
+                  <td class="td-left">Perfil de atuação</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.profileConfig.hasExpertiseBySector"
@@ -976,7 +976,7 @@
             <table class="table-modules">
               <tbody>
                 <tr>
-                  <td>Módulo de promoções</td>
+                  <td class="td-left">Módulo de promoções</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.modulesConfig.hasPromotion"
@@ -986,7 +986,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>Módulo de cursos</td>
+                  <td class="td-left">Módulo de cursos</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.modulesConfig.hasCourse"
@@ -1025,7 +1025,7 @@
             <table class="table-onedrive">
               <tbody>
                 <tr>
-                  <td>OneDrive</td>
+                  <td class="td-left">OneDrive</td>
                   <td>
                     <nb-toggle
                       [(ngModel)]="clonedConfig.oneDriveConfig.isActive"
@@ -1149,7 +1149,7 @@
               </thead>
               <tbody>
                 <tr>
-                  <td>
+                  <td style="text-align: left" class="td-left">
                     Fechamento de Contrato
                     <nb-icon
                       status="info"
@@ -1179,7 +1179,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>
+                  <td style="text-align: left" class="td-left">
                     Parcelas das Ordens de Empenho
                     <nb-icon
                       status="info"
@@ -1209,7 +1209,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>
+                  <td style="text-align: left" class="td-left">
                     Movimentação criada
                     <nb-icon
                       status="info"
@@ -1239,7 +1239,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>
+                  <td style="text-align: left" class="td-left">
                     Movimentação paga
                     <nb-icon
                       status="info"
@@ -1269,7 +1269,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>
+                  <td style="text-align: left" class="td-left">
                     Usuário mencionado
                     <nb-icon
                       status="info"
@@ -1299,7 +1299,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>
+                  <td style="text-align: left" class="td-left">
                     Atribuição em etapa do contrato
                     <nb-icon
                       status="info"
@@ -1329,7 +1329,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td>
+                  <td style="text-align: left" class="td-left">
                     Recebimento do valor total
                     <nb-icon
                       status="info"

--- a/src/app/@theme/components/header/config/config.component.scss
+++ b/src/app/@theme/components/header/config/config.component.scss
@@ -37,14 +37,24 @@
   .table-onedrive {
     text-align: left;
     .td-left {
-      padding: 10px 20px 20px 0;
+      padding-right: 20px;
+      padding-bottom: 12px;
+    }
+  }
+
+  .table-notification {
+    .td-left {
+      padding-right: 20px;
+      padding-bottom: 12px;
     }
   }
 
   .table-notification td,
   th {
+    text-align: center;
     border-right: var(--tabset-divider-width) var(--tabset-divider-style) var(--tabset-divider-color);
-    padding: 5px 10px 10px;
+    padding-left: 5px;
+    padding-right: 5px;
   }
 }
 


### PR DESCRIPTION
Centralizando os textos com os toggles
Exemplo com aba orçamento:
![invoice](https://user-images.githubusercontent.com/30202709/177894572-c432f8dd-bfba-497f-8b3d-2f026aba841e.jpg)

Exemplo com aba perfil:
![profile](https://user-images.githubusercontent.com/30202709/177894578-2bab7ec2-8757-45db-9dd9-affb9b4d1dae.jpg)

Exemplo com aba notificação:
![notif](https://user-images.githubusercontent.com/30202709/177894489-e3544b67-88ab-40f2-9ceb-7d761a69aaaf.png)
