### PR TITLE
[NINC-2096][NINC-2108] Feat: add to promotion route

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/order */
 import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
@@ -5,6 +6,9 @@ import helmet from 'helmet';
 import mongoose from 'mongoose';
 import cron from 'node-cron';
 import path from 'path';
+
+import { updateIfCurrentPlugin } from './models/shared/versionPlugin';
+mongoose.plugin(updateIfCurrentPlugin);
 
 import { NotificationApps } from './models/notification';
 // import logger from 'morgan';

--- a/backend/src/models/promotion.ts
+++ b/backend/src/models/promotion.ts
@@ -1,5 +1,4 @@
-import { DocumentType, getModelForClass, pre, prop } from '@typegoose/typegoose';
-import { UpdateQuery } from 'mongoose';
+import { getModelForClass, prop } from '@typegoose/typegoose';
 
 import { Base } from './base';
 
@@ -14,19 +13,6 @@ export class PromotionRule {
   value!: string;
 }
 
-@pre<Promotion>('findOneAndUpdate', function (next) {
-  const update = this.getUpdate() as UpdateQuery<DocumentType<Promotion>>;
-  if (update.__v) delete update.__v;
-  if (update['$set'] && update['$set'].__v) {
-    delete update['$set'].__v;
-    if (Object.keys(update['$set']).length === 0) {
-      delete update['$set'];
-    }
-  }
-  update['$inc'] = update['$inc'] || {};
-  update['$inc'].__v = 1;
-  next();
-})
 export class Promotion extends Base<string> {
   @prop({ required: true })
   name!: string;

--- a/backend/src/models/shared/versionPlugin.ts
+++ b/backend/src/models/shared/versionPlugin.ts
@@ -1,0 +1,17 @@
+import 'core-js/stable';
+
+import 'regenerator-runtime/runtime';
+
+/**
+ * Implement optimistic concurrency control on a Mongoose schema.
+ *
+ * @param {mongoose.Schema} schema - A Mongoose schema to be plugged into.
+ * @param {object} options - A Mongoose schema to be plugged into.
+ */
+
+export function updateIfCurrentPlugin(schema: any, options: any) {
+  schema.pre('findOneAndUpdate', function (next: any) {
+    this._update.__v += 1;
+    next();
+  });
+}

--- a/backend/src/models/shared/versionPlugin.ts
+++ b/backend/src/models/shared/versionPlugin.ts
@@ -1,7 +1,3 @@
-import 'core-js/stable';
-
-import 'regenerator-runtime/runtime';
-
 /**
  * Implement optimistic concurrency control on a Mongoose schema.
  *

--- a/backend/src/routes/promotion.ts
+++ b/backend/src/routes/promotion.ts
@@ -33,20 +33,18 @@ router.post('/', (req, res, next) => {
 
 router.post('/update', async (req, res, next) => {
   try {
-    const updatedUser = await PromotionModel.findOneAndUpdate(
+    const promotion = await PromotionModel.findOneAndUpdate(
       { _id: req.body.promotion._id, __v: req.body.promotion.__v },
       req.body.promotion,
-      {
-        upsert: false,
-      }
+      { upsert: false }
     );
-    if (!updatedUser)
+    if (!promotion)
       return res.status(500).json({
         message: 'O documento foi atualizado por outro usuário. Por favor, recarregue os dados e tente novamente.',
       });
     if (requested) {
       await mutex.runExclusive(async () => {
-        promotionsMap[req.body.promotion._id] = cloneDeep(updatedUser.toJSON());
+        promotionsMap[req.body.promotion._id] = cloneDeep(promotion.toJSON());
       });
     }
     return res.status(200).json({

--- a/backend/src/routes/promotion.ts
+++ b/backend/src/routes/promotion.ts
@@ -35,7 +35,7 @@ router.post('/update', async (req, res, next) => {
   try {
     const updatedUser = await PromotionModel.findOneAndUpdate(
       { _id: req.body.promotion._id, __v: req.body.promotion.__v },
-      { $set: req.body.promotion },
+      req.body.promotion,
       {
         upsert: false,
       }


### PR DESCRIPTION
- Processo de descoberta:

  - Cheguei ao resultado usando o método aplicado sobre getModelForClass(Promotion, { schemaOptions: { optimisticConcurrency: true } } ), porém, no caso do save temos que fazer cada atribuição por conta da atualização. Nisso, ocorreu problemas relacionados as propriedades com os decorators unique e required.
  - Como sabemos, só o método save() incrementa o __v (versionKey). Mas usando um middleware definida com o decorator pre podemos fazer o método de atualizar como update() e findOneAndUpdate() também incrementar, mas ao fazer o teste mantendo a propriedade acima definda não consegui obter o resultado desejado. Ele incrementa e mesmo com as versões desatualizadas consigo atualizar o documento.  É como se houvesse uma relação restrita a save() e esta propriedade.

- Acredito que esta solução pode ser reduzida sem a necessidade do pre 🤔

Link mostrando o middleware pre:
https://mongoosejs.com/docs/guide.html#optimisticConcurrency
Um ponto interessante é que o método save() acaba chamando o método updateOne:
https://thecodebarbarian.com/whats-new-in-mongoose-5-10-optimistic-concurrency.html